### PR TITLE
Auth & local

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -90,11 +90,13 @@ class Module
 			'invokables' => [
 				'FlightInfo\Service\User'					=> 'FlightInfo\Service\User',
 				'FlightInfo\Auth\Adapter'					=> 'FlightInfo\Auth\Adapter',
+                'FlightInfo\Auth\SwitchAdapter'					=> 'FlightInfo\Auth\SwitchAdapter',
 				'FlightInfo\Service\Airport' 			=> 'FlightInfo\Service\Airport',
 				'FlightInfo\Service\Airline' 			=> 'FlightInfo\Service\Airline',
 				'FlightInfo\Service\Flight' 			=> 'FlightInfo\Service\Flight',
 				'FlightInfo\Service\Flightnumber' => 'FlightInfo\Service\Flightnumber',
 				'FlightInfo\Service\XMLStream' 		=> 'FlightInfo\Service\XMLStream',
+                'Zend\Authentication\AuthenticationService' => 'FlightInfo\Auth\AuthenticationService'
 			],
 			'aliases' => array(
 				'UserService' => 'FlightInfo\Service\User',

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -44,6 +44,22 @@ return array(
             'action' => 'login'
           ),
         ),
+          'may_terminate' => true,
+          'child_routes' => array(
+              'index' => array(
+                  'type' => 'Zend\Mvc\Router\Http\Segment',
+                  'options' => array(
+                      'route' => '/switch/:id',
+                      'constraints' => array(
+                          'id' => '[0-9]*',
+                      ),
+                      'defaults' => array(
+                          'controller' => 'FlightInfo\Controller\Auth',
+                          'action' => 'switch'
+                      ),
+                  )
+              ),
+          ),
       ),
       'airport' => array(
         'type' => 'Zend\Mvc\Router\Http\Literal',

--- a/src/Flightinfo/Auth/AuthenticationService.php
+++ b/src/Flightinfo/Auth/AuthenticationService.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: einarvalur
+ * Date: 13/05/15
+ * Time: 7:37 AM
+ */
+
+namespace FlightInfo\Auth;
+
+use Zend\Authentication\AuthenticationService as BaseAuthService;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class AuthenticationService extends BaseAuthService implements ServiceLocatorAwareInterface
+{
+    protected $serviceLocator;
+
+    /**
+     * @todo implement
+     * @return bool
+     */
+    public function assert()
+    {
+        return true;
+    }
+
+    /**
+     * Check if logged in user is Admin
+     *
+     * @return bool
+     */
+    public function isAdmin()
+    {
+        if ($this->hasIdentity()) {
+            return $this->getIdentity()->is_admin;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Set service locator
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return $this
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+        return $this;
+    }
+
+    /**
+     * Get service locator
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator()
+    {
+        return $this->serviceLocator;
+    }
+}

--- a/src/Flightinfo/Auth/SwitchAdapter.php
+++ b/src/Flightinfo/Auth/SwitchAdapter.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: drupalviking
+ * Date: 05/05/15
+ * Time: 15:40
+ */
+namespace FlightInfo\Auth;
+
+use \PDO;
+use FlightInfo\Lib\DataSourceAwareInterface;
+use Zend\Authentication\Adapter\AdapterInterface;
+use Zend\Authentication\Result;
+
+class SwitchAdapter implements AdapterInterface, DataSourceAwareInterface
+{
+  /**
+   * @var \PDO
+   */
+  private $pdo;
+
+  /**
+   * @var int
+   */
+  private $id;
+
+  /**
+   * Performs an authentication attempt
+   *
+   * @return \Zend\Authentication\Result
+   * @throws \Zend\Authentication\Adapter\Exception\ExceptionInterface If authentication cannot be performed
+   */
+  public function authenticate()
+  {
+
+      $statement = $this->pdo
+        ->prepare("
+				SELECT * FROM `User`
+				WHERE id = :id");
+      $statement->execute(array(
+        'id' => $this->id,
+      ));
+
+    $result = $statement->fetchAll();
+    if (count($result) == 0) {
+      return new Result(Result::FAILURE_IDENTITY_NOT_FOUND, null);
+    } else if (count($result) == 1) {
+      $data = $result[0];
+      unset($data->passwd);
+      return new Result(Result::SUCCESS, $result[0]);
+    } else {
+      return new Result(Result::FAILURE_IDENTITY_AMBIGUOUS, null);
+    }
+  }
+
+  /**
+   * You can authenticate based on username/password
+   * or by using the user's ID. If this value is set
+   * then the user's ID will be used to identify.
+   *
+   * So use this method or self::setCredentials, but
+   * not both.
+   *
+   * @param $id
+   */
+  public function setIdentifier($id)
+  {
+    $this->id = $id;
+  }
+
+  /**
+   * Set username and password
+   *
+   * You can authenticate based on username/password
+   * or by using the user's ID. If this value is set
+   * then the user's username/password will be used to
+   * identify.
+   *
+   * So use this method or self::setIdentifier, but
+   * not both.
+   *
+   * @param $username
+   * @param $password
+   */
+  public function setCredentials($username, $password)
+  {
+        throw new \InvalidArgumentException("Can't set username and password for this " . get_class($this));
+  }
+
+  /**
+   * Set a configured PDO object.
+   *
+   * @param \PDO $pdo
+   * @return mixed
+   */
+  public function setDataSource(\PDO $pdo)
+  {
+    $this->pdo = $pdo;
+  }
+}

--- a/src/Flightinfo/Controller/AirlineController.php
+++ b/src/Flightinfo/Controller/AirlineController.php
@@ -56,9 +56,10 @@ class AirlineController extends AbstractActionController
   public function createAction(){
     $sm = $this->getServiceLocator();
     $airlineService = $sm->get('FlightInfo\Service\Airline');
-    $authService = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
-    if( $authService->hasIdentity() && $authService->getIdentity()->id == 1){
+      if ($authService->isAdmin()) {
       $form = new AirlineForm();
       //POST
       //  http post request
@@ -91,9 +92,10 @@ class AirlineController extends AbstractActionController
   public function updateAction(){
     $sm = $this->getServiceLocator();
     $airlineService = $sm->get('FlightInfo\Service\Airline');
-    $authService = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
-    if( $authService->hasIdentity() && $authService->getIdentity()->id == 1){
+    if($authService->isAdmin()){
       $form = new AirlineForm();
       if (($airline = $airlineService->get($this->params()->fromRoute('id')) ) != false) {
         //POST

--- a/src/Flightinfo/Controller/AirlineController.php
+++ b/src/Flightinfo/Controller/AirlineController.php
@@ -7,9 +7,6 @@
  */
 namespace FlightInfo\Controller;
 
-date_default_timezone_set('UTC');
-setlocale(LC_ALL, 'is_IS');
-
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\Stdlib\ArrayObject;
 use Zend\View\Model\ViewModel;

--- a/src/Flightinfo/Controller/AirportController.php
+++ b/src/Flightinfo/Controller/AirportController.php
@@ -55,9 +55,10 @@ class AirportController extends AbstractActionController
   public function createAction(){
     $sm = $this->getServiceLocator();
     $airportService = $sm->get('FlightInfo\Service\Airport');
-    $auth = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
-    if( $auth->hasIdentity() && $auth->getIdentity()->id == 1) {
+    if($authService->isAdmin()) {
       $form = new AirportForm();
       //POST
       //  http post request
@@ -95,9 +96,10 @@ class AirportController extends AbstractActionController
   public function updateAction(){
     $sm = $this->getServiceLocator();
     $airportService = $sm->get('FlightInfo\Service\Airport');
-    $auth = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
-    if( $auth->hasIdentity() && $auth->getIdentity()->id == 1) {
+    if($authService->isAdmin()) {
       $form = new AirportForm();
       if (($airport = $airportService->get($this->params()->fromRoute('id')) ) != false) {
         //POST

--- a/src/Flightinfo/Controller/AirportController.php
+++ b/src/Flightinfo/Controller/AirportController.php
@@ -7,9 +7,6 @@
  */
 namespace FlightInfo\Controller;
 
-date_default_timezone_set('UTC');
-setlocale(LC_ALL, 'is_IS');
-
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\Stdlib\ArrayObject;
 use Zend\View\Model\ViewModel;

--- a/src/Flightinfo/Controller/AuthController.php
+++ b/src/Flightinfo/Controller/AuthController.php
@@ -68,6 +68,23 @@ class AuthController extends AbstractActionController
     }
   }
 
+    public function switchAction()
+    {
+        $sm = $this->getServiceLocator();
+        $auth = $sm->get('Zend\Authentication\AuthenticationService');
+
+        $sm->get('FlightInfo\Auth\SwitchAdapter');
+
+        $authAdapter =  $sm->get('FlightInfo\Auth\Adapter');
+        $authAdapter->setIdentifier($this->params('id'));
+        $result = $auth->authenticate($authAdapter);
+        if ($result->isValid()) {
+            return $this->redirect()->toRoute('home');
+        } else {
+            throw new \Exception("User [{$this->params('id')}] not found");
+        }
+    }
+
   /**
    * Last installment of creating user in the system.
    *
@@ -110,7 +127,8 @@ class AuthController extends AbstractActionController
    */
   public function loginAction()
   {
-    $auth = new AuthenticationService();
+      $sm = $this->getServiceLocator();
+      $auth = $sm->get('Zend\Authentication\AuthenticationService');
 
     //IS LOGGED IN
     //  user is logged in

--- a/src/Flightinfo/Controller/FlightController.php
+++ b/src/Flightinfo/Controller/FlightController.php
@@ -18,7 +18,8 @@ class FlightController extends AbstractActionController{
     $sm = $this->getServiceLocator();
     $flightService = $sm->get('FlightInfo\Service\Flight');
     $airportService = $sm->get('FlightInfo\Service\Airport');
-    $auth = new AuthenticationService();
+      $auth = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
     //FLIGHT FOUND
     //
@@ -40,7 +41,8 @@ class FlightController extends AbstractActionController{
     $sm = $this->getServiceLocator();
     $flightService = $sm->get('FlightInfo\Service\Flight');
     $airportService = $sm->get('FlightInfo\Service\Airport');
-    $auth = new AuthenticationService();
+      $auth = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
     //////////////////////////////////////////
     //// XML STREAM FUNCTIONS
@@ -69,7 +71,8 @@ class FlightController extends AbstractActionController{
     $airportService = $sm->get('FlightInfo\Service\Airport');
     $airlineService = $sm->get('FlightInfo\Service\Airline');
     $flightnumberService = $sm->get('FlightInfo\Service\Flightnumber');
-    $auth = new AuthenticationService();
+      $auth = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
     if($auth->hasIdentity() ) {
       $form = new FlightForm($airportService);
@@ -115,7 +118,8 @@ class FlightController extends AbstractActionController{
     $flightService = $sm->get('FlightInfo\Service\Flight');
     $airportService = $sm->get('FlightInfo\Service\Airport');
     $flightnumberService = $sm->get('FlightInfo\Service\Flightnumber');
-    $authService = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
     //FLIGHT FOUND
     //

--- a/src/Flightinfo/Controller/UserController.php
+++ b/src/Flightinfo/Controller/UserController.php
@@ -31,9 +31,10 @@ class UserController extends AbstractActionController{
   public function indexAction(){
     $sm = $this->getServiceLocator();
     $userService = $sm->get('FlightInfo\Service\User');
-    $auth = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
-    if($auth->hasIdentity() && $auth->getIdentity()->is_admin == 1) {
+    if($authService->isAdmin()) {
       if (($user = $userService->get($this->params()
           ->fromRoute('id', 0))) != FALSE
       ) {
@@ -56,9 +57,10 @@ class UserController extends AbstractActionController{
     $sm = $this->getServiceLocator();
     $userService = $sm->get('FlightInfo\Service\User');
 
-    $auth = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
-    if($auth->hasIdentity() && $auth->getIdentity()->is_admin == 1) {
+    if($authService->isAdmin()) {
       if (($users = $userService->fetchAll()) != FALSE) {
         return new ViewModel(
           [
@@ -79,9 +81,10 @@ class UserController extends AbstractActionController{
     $sm = $this->getServiceLocator();
     $userService = $sm->get('FlightInfo\Service\User');
     $airlineService = $sm->get('FlightInfo\Service\Airline');
-    $auth = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
-    if($auth->hasIdentity() && $auth->getIdentity()->is_admin == 1) {
+    if($authService->isAdmin()) {
       $form = new UserForm($airlineService);
 
       if ($this->request->isPost()) {
@@ -116,9 +119,10 @@ class UserController extends AbstractActionController{
     $sm = $this->getServiceLocator();
     $userService = $sm->get('FlightInfo\Service\User');
     $airlineService = $sm->get('FlightInfo\Service\Airline');
-    $auth = new AuthenticationService();
+      $authService = $sm->get('Zend\Authentication\AuthenticationService');
+      /** @var $authService \FlightInfo\Auth\AuthenticationService */
 
-    if($auth->hasIdentity() && $auth->getIdentity()->is_admin == 1) {
+    if($authService->isAdmin()) {
       if (($user = $userService->get($this->params()->fromRoute('id')) ) != false) {
         $form = new UserForm($airlineService);
         $form->setAttribute('action', $this->url()->fromRoute('user/update', ['id'=>$user->id]));

--- a/src/Flightinfo/Service/Airline.php
+++ b/src/Flightinfo/Service/Airline.php
@@ -7,9 +7,6 @@
  */
 namespace FlightInfo\Service;
 
-date_default_timezone_set('UTC');
-setlocale(LC_ALL, 'is_IS');
-
 use PDOException;
 use FlightInfo\Lib\DataSourceAwareInterface;
 use FlightInfo\Service\DatabaseService;

--- a/src/Flightinfo/Service/Flight.php
+++ b/src/Flightinfo/Service/Flight.php
@@ -7,9 +7,6 @@
  */
 namespace FlightInfo\Service;
 
-date_default_timezone_set('UTC');
-setlocale(LC_ALL, 'is_IS');
-
 use PDOException;
 use FlightInfo\Lib\DataSourceAwareInterface;
 use FlightInfo\Service\DatabaseService;

--- a/src/Flightinfo/Service/Flightnumber.php
+++ b/src/Flightinfo/Service/Flightnumber.php
@@ -7,9 +7,6 @@
  */
 namespace FlightInfo\Service;
 
-date_default_timezone_set('UTC');
-setlocale(LC_ALL, 'is_IS');
-
 use PDOException;
 use FlightInfo\Lib\DataSourceAwareInterface;
 use FlightInfo\Service\DatabaseService;

--- a/src/Flightinfo/Service/User.php
+++ b/src/Flightinfo/Service/User.php
@@ -7,9 +7,6 @@
  */
 namespace FlightInfo\Service;
 
-date_default_timezone_set('UTC');
-setlocale(LC_ALL, 'is_IS');
-
 use \DateTime;
 use \PDOException;
 use FlightInfo\Lib\DataSourceAwareInterface;

--- a/src/Flightinfo/Service/XMLStream.php
+++ b/src/Flightinfo/Service/XMLStream.php
@@ -7,9 +7,6 @@
  */
 namespace FlightInfo\Service;
 
-date_default_timezone_set('UTC');
-setlocale(LC_ALL, 'is_IS');
-
 use PDOException;
 use FlightInfo\Lib\DataSourceAwareInterface;
 use FlightInfo\Service\DatabaseService;


### PR DESCRIPTION
Tessi PR gerir thrir hluti
### 1

`date_default_timezone_set('UTC');` og `setlocale(LC_ALL, 'is_IS');` er tekid utur kodanum. Best er ad geyma tad bara i `index.php`

``` php
<?php

date_default_timezone_set('UTC');
setlocale(LC_ALL, 'is_IS');

/**
 * This makes our life easier when dealing with paths. Everything is relative
 * to the application root now.
 */
chdir(dirname(__DIR__));

// Decline static file requests back to the PHP built-in webserver
if (php_sapi_name() === 'cli-server' && is_file(__DIR__ . parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))) {
    return false;
}

// Setup autoloading
require 'init_autoloader.php';

// Run the application!
Zend\Mvc\Application::init(require 'config/application.config.php')->run();
```
### 2

AuthService var sett i Service manager'inn og hun gerd `ServiceLocatorAwareInterface`. Hun var somuleidis extended svo ad nu er haegt ad kalla a i controller `$auth->isAdmin()`
### 3

Buin var til _route_ `innskra/switch/:id` sem mun uppfaera Auth service og setja a tann user sem ID var sent inn. IE. ef tu villt vera notandi _1_ ta ferdu bara a `/innskra/switch/1`
